### PR TITLE
Exercício cashmashine, remoção warning HarryPotter

### DIFF
--- a/sestrem/cashmashine/.formatter.exs
+++ b/sestrem/cashmashine/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/sestrem/cashmashine/.gitignore
+++ b/sestrem/cashmashine/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+cashmashine-*.tar
+

--- a/sestrem/cashmashine/README.md
+++ b/sestrem/cashmashine/README.md
@@ -1,0 +1,3 @@
+# Exercício Caixa Eletrônico
+
+Simular o funcionamento de um caixa eletrônico retornando a quantidade de cédulas necessárias para atender a solicitação de determinado valor.

--- a/sestrem/cashmashine/lib/cashmachine_refatorado.ex
+++ b/sestrem/cashmashine/lib/cashmachine_refatorado.ex
@@ -1,0 +1,45 @@
+defmodule CashMachine do
+  @bank_notes [100, 50, 20, 10, 5, 2]
+
+  defp count_notes(0, _, notes_compound_result) do
+    notes_compound_result
+  end
+
+  defp count_notes(_, [], _) do
+    %{:error => "Invalid amount"}
+  end
+
+  defp count_notes(amount, [note_value | bank_notes], notes_compound_result) do
+    notes_quantity = div(amount, note_value)
+    subtracted_amount = amount - notes_quantity * note_value
+
+    count_notes(
+      subtracted_amount,
+      bank_notes,
+      Map.put_new(notes_compound_result, note_value, notes_quantity)
+    )
+  end
+
+  def withdraw(amount) do
+    amount
+    |> count_notes(@bank_notes, %{})
+    |> Enum.filter(fn {_note_value, note_quantity} -> note_quantity > 0 end)
+    |> Map.new()
+  end
+
+  """
+  ordeno o map retornado para que os primeiros elementos sejam os que tenham qtde > 0
+  Reduce possui um acumulador. Então executo o reduce enquanto a qtde de notas do elemento for > 0, adicionando no acumulador do reduce este elemento
+  se qtde de notas = 0, paro o reduce (:halt), não é necessário verificar os demais elementos pq todos eles estarão com a qtde notas = 0
+  (foram ordenados no passo anterior: Enum.sort)
+  """
+  def withdraw_reduce(amount) do
+    amount |> count_notes(@bank_notes, %{})
+           |> Enum.sort(fn ({_k1, val1}, {_k2, val2}) -> val1 > val2 end)
+           |> Enum.reduce_while([], fn(x, acc) ->
+                                      qtde_note = elem(x, 1)
+                                      if qtde_note > 0, do: {:cont, [x | acc]}, else: {:halt, acc}
+                                    end)
+						
+  end
+end

--- a/sestrem/cashmashine/mix.exs
+++ b/sestrem/cashmashine/mix.exs
@@ -1,0 +1,28 @@
+defmodule Cashmashine.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :cashmashine,
+      version: "0.1.0",
+      elixir: "~> 1.10",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/sestrem/cashmashine/test/cashmashine_test.exs
+++ b/sestrem/cashmashine/test/cashmashine_test.exs
@@ -1,0 +1,28 @@
+defmodule CashmachineTest do
+  use ExUnit.Case
+  doctest CashMachine
+
+  test "There is no bills for 1 dollar" do
+    assert CashMachine.withdraw(1) == %{error: "Invalid amount"}
+  end
+
+  test "2 dollars give me a 2-dollar bill" do
+    assert CashMachine.withdraw(2) == %{2 => 1}
+  end
+
+  test "187 dollars gives me one of each bill" do
+    assert CashMachine.withdraw(187) == %{2 => 1, 5 => 1, 10 => 1, 20 => 1, 50 => 1, 100 => 1}
+  end
+
+  test "200 dollars gives me two 100 dollar bills" do
+    assert CashMachine.withdraw(200) == %{100 => 2}
+  end
+
+  test "Tests using Enum.reduduce_while" do
+    assert CashMachine.withdraw_reduce(200) ==  [{100, 2}]
+
+    assert CashMachine.withdraw_reduce(187) == [{2, 1}, {5, 1}, {10, 1}, {20, 1}, {50, 1}, {100, 1}]
+
+    assert CashMachine.withdraw_reduce(289) ==  [{5, 1}, {10, 1}, {20, 1}, {50, 1}, {2, 2}, {100, 2}]
+  end
+end

--- a/sestrem/cashmashine/test/test_helper.exs
+++ b/sestrem/cashmashine/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/sestrem/harrypotterbookstore/lib/harry_potter_bookstore.ex
+++ b/sestrem/harrypotterbookstore/lib/harry_potter_bookstore.ex
@@ -26,27 +26,6 @@ defmodule HarryPotterBookstore do
   def _desconto(4) do 0.8 end
   def _desconto(5) do 0.75 end
 
-  def full_price_second_task_v2(shopping_cart, price) do
-    full_price = (Enum.map(shopping_cart, fn {_livro, quantidade} -> quantidade end) |> Enum.sum()) * price
-
-    livros = Enum.map(shopping_cart, fn {livro, quantidade} ->%{:livro => livro, :quantidade => quantidade} end)
-    IO.inspect livros
-    #livros_unicos = Enum.uniq(livros.livro)
-
-    #livros_unicos = Enum.uniq_by([livros], fn {x, _} -> x end)
-    livros_unicos = Enum.into(livros, MapSet.new())
-    IO.puts "livros únicos"
-    IO.inspect livros_unicos
-    #IO.inspect livros_unicos
-
-
-
-
-    #qtde_livros_unicos = Enum.uniq(livros) |> Enum.count()
-
-    #full_price * _desconto(qtde_livros_unicos)
-  end
-
   @spec full_price_third_task(any, number) :: number
   def full_price_third_task(shopping_cart, price) do
     full_price = (Enum.map(shopping_cart, fn {_livro, quantidade} -> quantidade end) |> Enum.sum()) * price


### PR DESCRIPTION
- Exercício cashmashine.
- Remoção de uma API desnecessária do HarryPotter e consequentemente de um warning.